### PR TITLE
Fix compatibility issue for Windows (Issue#1).

### DIFF
--- a/lib/compass-validator.rb
+++ b/lib/compass-validator.rb
@@ -1,5 +1,6 @@
 # This file was extracted from the blueprint project and then modified.
 require "open3"
+require "rbconfig"
 
 module Compass
   # Validates generated CSS against the W3 using Java
@@ -28,7 +29,14 @@ module Compass
 
     # Validates all three CSS files
     def validate
-      java_path = `which java`.rstrip
+      if (!(RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/))
+		    java_path = `which java`.rstrip
+	    else
+		    java_path = `where java`.rstrip
+		    if (!java_path || java_path.empty?)
+		      java_path = `WHERE /R C:\\ java`.rstrip
+		    end
+	    end
       raise "You do not have a Java installed, but it is required." unless java_path && !java_path.empty?
     
       Dir.glob(File.join(css_directory, "**", "*.css")).each do |file_name|


### PR DESCRIPTION
Replace "which" command with "where" for Windows instances. Fixes https://github.com/chriseppstein/compass-validator/issues/1.

"By default, the search is done along the current directory and in the paths specified by the PATH environment variable" (from "where" command-line help). In some cases, this fails to find a Java installation located on a different drive than the drive from which the validator is being called. To counter this, this code adds a second "where" call with the C:\ path hard-coded should the default search path(s) fail. This hard-coded path should eventually be converted to a configuration value to allow override.

Tested successfully on Windows Server 2012 R2 Standard.
